### PR TITLE
backstabbing knife toggle

### DIFF
--- a/lua/tttwr/sh_knife.lua
+++ b/lua/tttwr/sh_knife.lua
@@ -1,3 +1,5 @@
+local ttt_backstab_knife = CreateConVar("ttt_backstab_knife", 1, FCVAR_ARCHIVE + FCVAR_NOTIFY)
+
 local SWEP = weapons.GetStored("weapon_ttt_knife")
 local ENT = scripted_ents.GetStored("ttt_knife_proj").t
 
@@ -12,6 +14,10 @@ ENT.KillPlayer = nil
 local vec, vec2 = Vector(), Vector()
 
 function SWEP:CanBackstabTarget(owner, victim, opos, aimvec)
+	// if we have backstabbing disabled, its always an insta kill :D
+	if !ttt_backstab_knife:GetBool() then
+		return true
+	end
 	opos = opos or owner:GetShootPos()
 	local vpos = victim:GetShootPos()
 


### PR DESCRIPTION
Some players prefer to not have backstab knife. I think it would make skilled players win over less skilled players, and make there little to no advantage to using it over almost any other weapon for less skilled players.

If ttt_backstab_knife is set to 1, which is default, backstab knife is enabled. If it is set to 0, it instead goes into one hit mode. (I mostly did this because my one hit knife addon loads before this addon)